### PR TITLE
feat: launch at login via XDG autostart

### DIFF
--- a/castword/autostart.py
+++ b/castword/autostart.py
@@ -1,0 +1,37 @@
+"""Manage XDG autostart for castword.
+
+The autostart entry is a .desktop file placed in ~/.config/autostart/.
+Its existence is the canonical state — no GSettings key is needed, and
+this keeps the setting in sync with GNOME Tweaks automatically.
+"""
+
+from pathlib import Path
+
+_AUTOSTART_DIR = Path.home() / ".config" / "autostart"
+_AUTOSTART_FILE = _AUTOSTART_DIR / "xyz.shapemachine.castword-gnome.desktop"
+
+_DESKTOP_CONTENT = """\
+[Desktop Entry]
+Type=Application
+Name=Castword
+Comment=Rewrite text in any tone with a keypress
+Exec=castword --background
+Icon=xyz.shapemachine.castword-gnome
+X-GNOME-Autostart-enabled=true
+Hidden=false
+NoDisplay=true
+"""
+
+
+def is_autostart_enabled() -> bool:
+    """Return True if the autostart desktop file exists."""
+    return _AUTOSTART_FILE.exists()
+
+
+def set_autostart_enabled(enabled: bool) -> None:
+    """Create or remove the autostart desktop file."""
+    if enabled:
+        _AUTOSTART_DIR.mkdir(parents=True, exist_ok=True)
+        _AUTOSTART_FILE.write_text(_DESKTOP_CONTENT)
+    else:
+        _AUTOSTART_FILE.unlink(missing_ok=True)

--- a/castword/autostart.py
+++ b/castword/autostart.py
@@ -5,22 +5,26 @@ Its existence is the canonical state — no GSettings key is needed, and
 this keeps the setting in sync with GNOME Tweaks automatically.
 """
 
+import shutil
 from pathlib import Path
 
 _AUTOSTART_DIR = Path.home() / ".config" / "autostart"
 _AUTOSTART_FILE = _AUTOSTART_DIR / "xyz.shapemachine.castword-gnome.desktop"
 
-_DESKTOP_CONTENT = """\
-[Desktop Entry]
-Type=Application
-Name=Castword
-Comment=Rewrite text in any tone with a keypress
-Exec=castword --background
-Icon=xyz.shapemachine.castword-gnome
-X-GNOME-Autostart-enabled=true
-Hidden=false
-NoDisplay=true
-"""
+
+def _desktop_content() -> str:
+    exec_path = shutil.which("castword") or "castword"
+    return (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        "Name=Castword\n"
+        "Comment=Rewrite text in any tone with a keypress\n"
+        f"Exec={exec_path} --background\n"
+        "Icon=xyz.shapemachine.castword-gnome\n"
+        "X-GNOME-Autostart-enabled=true\n"
+        "Hidden=false\n"
+        "NoDisplay=true\n"
+    )
 
 
 def is_autostart_enabled() -> bool:
@@ -32,6 +36,6 @@ def set_autostart_enabled(enabled: bool) -> None:
     """Create or remove the autostart desktop file."""
     if enabled:
         _AUTOSTART_DIR.mkdir(parents=True, exist_ok=True)
-        _AUTOSTART_FILE.write_text(_DESKTOP_CONTENT)
+        _AUTOSTART_FILE.write_text(_desktop_content())
     else:
         _AUTOSTART_FILE.unlink(missing_ok=True)

--- a/castword/main.py
+++ b/castword/main.py
@@ -21,6 +21,11 @@ class CastwordApplication(Adw.Application):
             # Keep the process resident after the window is hidden so
             # D-Bus re-activation can re-present it instantly.
             self.hold()
+            # When started with --background (e.g. XDG autostart at login),
+            # stay resident but don't show the window — wait for the first
+            # keyboard-shortcut / D-Bus activation to present it.
+            if "--background" in sys.argv:
+                return
 
         if self._window.get_visible():
             self._window.toggle_mic()

--- a/castword/main.py
+++ b/castword/main.py
@@ -12,20 +12,25 @@ class CastwordApplication(Adw.Application):
         self.connect("activate", self._on_activate)
         self.set_resource_base_path("/xyz/shapemachine/castword-gnome")
         self._window = None
+        # Captured once at startup; cleared after the first activation so
+        # subsequent D-Bus activations (keyboard shortcut) create the window.
+        self._background_start = "--background" in sys.argv
 
     def _on_activate(self, app):
-        from castword.window import CastwordWindow
-
         if self._window is None:
+            if self._background_start:
+                # Stay resident without creating the window or showing any
+                # first-run dialogs. The next D-Bus activation (keyboard
+                # shortcut) will create the window and present it normally.
+                self._background_start = False
+                self.hold()
+                return
+
+            from castword.window import CastwordWindow
             self._window = CastwordWindow(application=self)
             # Keep the process resident after the window is hidden so
             # D-Bus re-activation can re-present it instantly.
             self.hold()
-            # When started with --background (e.g. XDG autostart at login),
-            # stay resident but don't show the window — wait for the first
-            # keyboard-shortcut / D-Bus activation to present it.
-            if "--background" in sys.argv:
-                return
 
         if self._window.get_visible():
             self._window.toggle_mic()

--- a/castword/preferences.py
+++ b/castword/preferences.py
@@ -503,8 +503,19 @@ class CastwordPreferences(Adw.PreferencesWindow):
             subtitle="Start castword automatically when you log in",
             active=is_autostart_enabled(),
         )
-        autostart_row.connect("notify::active",
-                              lambda row, _: set_autostart_enabled(row.get_active()))
+
+        handler_id_ref = [None]
+
+        def _on_autostart_toggled(row, _param):
+            try:
+                set_autostart_enabled(row.get_active())
+            except OSError as e:
+                row.handler_block(handler_id_ref[0])
+                row.set_active(not row.get_active())
+                row.handler_unblock(handler_id_ref[0])
+                self.add_toast(Adw.Toast(title=f"Could not update autostart: {e}", timeout=4))
+
+        handler_id_ref[0] = autostart_row.connect("notify::active", _on_autostart_toggled)
         startup_group.add(autostart_row)
 
         return page

--- a/castword/preferences.py
+++ b/castword/preferences.py
@@ -494,6 +494,19 @@ class CastwordPreferences(Adw.PreferencesWindow):
         shortcut_row.add_suffix(open_kb_btn)
         shortcut_group.add(shortcut_row)
 
+        startup_group = Adw.PreferencesGroup(title="Startup")
+        page.add(startup_group)
+
+        from castword.autostart import is_autostart_enabled, set_autostart_enabled
+        autostart_row = Adw.SwitchRow(
+            title="Launch at Login",
+            subtitle="Start castword automatically when you log in",
+            active=is_autostart_enabled(),
+        )
+        autostart_row.connect("notify::active",
+                              lambda row, _: set_autostart_enabled(row.get_active()))
+        startup_group.add(autostart_row)
+
         return page
 
     def _on_output_mode_changed(self, combo, _param):

--- a/castword/window.py
+++ b/castword/window.py
@@ -410,28 +410,45 @@ class CastwordWindow(Adw.ApplicationWindow):
         self._prefs_open = True
         dialog = Adw.AlertDialog(
             heading="Set up castword",
-            body="Register Super+Shift+W to open castword from anywhere, and start it automatically when you log in.",
+            body="You can change these any time in Preferences.",
         )
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(8)
+        shortcut_check = Gtk.CheckButton(
+            label="Register Super+Shift+W global shortcut",
+            active=True,
+        )
+        autostart_check = Gtk.CheckButton(
+            label="Launch at login",
+            active=True,
+        )
+        box.append(shortcut_check)
+        box.append(autostart_check)
+        dialog.set_extra_child(box)
+
         dialog.add_response("skip", "Not Now")
         dialog.add_response("setup", "Set Up")
         dialog.set_response_appearance("setup", Adw.ResponseAppearance.SUGGESTED)
         dialog.set_default_response("setup")
-        dialog.connect("response", self._on_shortcut_prompt_response)
+        dialog.connect("response", self._on_shortcut_prompt_response, shortcut_check, autostart_check)
         dialog.present(self)
         return GLib.SOURCE_REMOVE
 
-    def _on_shortcut_prompt_response(self, dialog, response):
+    def _on_shortcut_prompt_response(self, dialog, response, shortcut_check, autostart_check):
         self._prefs_open = False
         if response != "setup":
             return
-        from castword.shortcuts import find_conflicting_shortcut, format_binding, DEFAULT_BINDING
-        from castword.autostart import set_autostart_enabled
-        set_autostart_enabled(True)
-        conflict_path, conflict_name = find_conflicting_shortcut(DEFAULT_BINDING)
-        if conflict_path:
-            self._show_shortcut_conflict_dialog(conflict_path, conflict_name, format_binding(DEFAULT_BINDING))
-        else:
-            self._do_register_shortcut()
+        if autostart_check.get_active():
+            from castword.autostart import set_autostart_enabled
+            set_autostart_enabled(True)
+        if shortcut_check.get_active():
+            from castword.shortcuts import find_conflicting_shortcut, format_binding, DEFAULT_BINDING
+            conflict_path, conflict_name = find_conflicting_shortcut(DEFAULT_BINDING)
+            if conflict_path:
+                self._show_shortcut_conflict_dialog(conflict_path, conflict_name, format_binding(DEFAULT_BINDING))
+            else:
+                self._do_register_shortcut()
 
     def _show_shortcut_conflict_dialog(self, conflict_path: str, conflict_name: str, binding_label: str):
         self._prefs_open = True

--- a/castword/window.py
+++ b/castword/window.py
@@ -409,8 +409,8 @@ class CastwordWindow(Adw.ApplicationWindow):
 
         self._prefs_open = True
         dialog = Adw.AlertDialog(
-            heading="Set up keyboard shortcut?",
-            body="Register Super+Shift+W to open castword from anywhere.",
+            heading="Set up castword",
+            body="Register Super+Shift+W to open castword from anywhere, and start it automatically when you log in.",
         )
         dialog.add_response("skip", "Not Now")
         dialog.add_response("setup", "Set Up")
@@ -425,6 +425,8 @@ class CastwordWindow(Adw.ApplicationWindow):
         if response != "setup":
             return
         from castword.shortcuts import find_conflicting_shortcut, format_binding, DEFAULT_BINDING
+        from castword.autostart import set_autostart_enabled
+        set_autostart_enabled(True)
         conflict_path, conflict_name = find_conflicting_shortcut(DEFAULT_BINDING)
         if conflict_path:
             self._show_shortcut_conflict_dialog(conflict_path, conflict_name, format_binding(DEFAULT_BINDING))

--- a/castword/window.py
+++ b/castword/window.py
@@ -56,7 +56,11 @@ class CastwordWindow(Adw.ApplicationWindow):
         self.connect("show", self._on_window_shown)
         self.connect("hide", self._on_window_hidden)
 
-        if not self._settings.get_boolean("shortcut-prompted"):
+        from castword.autostart import is_autostart_enabled
+        needs_shortcut_prompt = not self._settings.get_boolean("shortcut-prompted")
+        needs_autostart_prompt = (not self._settings.get_boolean("autostart-prompted")
+                                  and not is_autostart_enabled())
+        if needs_shortcut_prompt or needs_autostart_prompt:
             self._prefs_open = True  # block focus-out dismiss while prompt is pending
             GLib.idle_add(self._prompt_shortcut_setup)
 
@@ -400,14 +404,20 @@ class CastwordWindow(Adw.ApplicationWindow):
 
     def _prompt_shortcut_setup(self):
         from castword.shortcuts import find_castword_shortcut
-        self._settings.set_boolean("shortcut-prompted", True)
-        _, binding = find_castword_shortcut()
-        if binding is not None:
-            self._prefs_open = False  # no dialog needed, unblock focus-out dismiss
-            self._maybe_start_recorder()
-            return GLib.SOURCE_REMOVE  # already configured
+        from castword.autostart import is_autostart_enabled
 
-        self._prefs_open = True
+        self._settings.set_boolean("shortcut-prompted", True)
+        self._settings.set_boolean("autostart-prompted", True)
+
+        _, binding = find_castword_shortcut()
+        shortcut_needed = binding is None
+        autostart_needed = not is_autostart_enabled()
+
+        if not shortcut_needed and not autostart_needed:
+            self._prefs_open = False
+            self._maybe_start_recorder()
+            return GLib.SOURCE_REMOVE
+
         dialog = Adw.AlertDialog(
             heading="Set up castword",
             body="You can change these any time in Preferences.",
@@ -415,18 +425,19 @@ class CastwordWindow(Adw.ApplicationWindow):
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         box.set_margin_top(8)
-        shortcut_check = Gtk.CheckButton(
-            label="Register Super+Shift+W global shortcut",
-            active=True,
-        )
-        autostart_check = Gtk.CheckButton(
-            label="Launch at login",
-            active=True,
-        )
-        box.append(shortcut_check)
-        box.append(autostart_check)
-        dialog.set_extra_child(box)
 
+        shortcut_check = None
+        if shortcut_needed:
+            shortcut_check = Gtk.CheckButton(
+                label="Register Super+Shift+W global shortcut",
+                active=True,
+            )
+            box.append(shortcut_check)
+
+        autostart_check = Gtk.CheckButton(label="Launch at login", active=True)
+        box.append(autostart_check)
+
+        dialog.set_extra_child(box)
         dialog.add_response("skip", "Not Now")
         dialog.add_response("setup", "Set Up")
         dialog.set_response_appearance("setup", Adw.ResponseAppearance.SUGGESTED)
@@ -442,7 +453,7 @@ class CastwordWindow(Adw.ApplicationWindow):
         if autostart_check.get_active():
             from castword.autostart import set_autostart_enabled
             set_autostart_enabled(True)
-        if shortcut_check.get_active():
+        if shortcut_check is not None and shortcut_check.get_active():
             from castword.shortcuts import find_conflicting_shortcut, format_binding, DEFAULT_BINDING
             conflict_path, conflict_name = find_conflicting_shortcut(DEFAULT_BINDING)
             if conflict_path:

--- a/castword/window.py
+++ b/castword/window.py
@@ -454,7 +454,10 @@ class CastwordWindow(Adw.ApplicationWindow):
             return
         if autostart_check is not None and autostart_check.get_active():
             from castword.autostart import set_autostart_enabled
-            set_autostart_enabled(True)
+            try:
+                set_autostart_enabled(True)
+            except OSError as e:
+                self._show_banner(f"Could not enable autostart: {e}")
         if shortcut_check is not None and shortcut_check.get_active():
             from castword.shortcuts import find_conflicting_shortcut, format_binding, DEFAULT_BINDING
             conflict_path, conflict_name = find_conflicting_shortcut(DEFAULT_BINDING)

--- a/castword/window.py
+++ b/castword/window.py
@@ -434,8 +434,10 @@ class CastwordWindow(Adw.ApplicationWindow):
             )
             box.append(shortcut_check)
 
-        autostart_check = Gtk.CheckButton(label="Launch at login", active=True)
-        box.append(autostart_check)
+        autostart_check = None
+        if autostart_needed:
+            autostart_check = Gtk.CheckButton(label="Launch at login", active=True)
+            box.append(autostart_check)
 
         dialog.set_extra_child(box)
         dialog.add_response("skip", "Not Now")
@@ -450,7 +452,7 @@ class CastwordWindow(Adw.ApplicationWindow):
         self._prefs_open = False
         if response != "setup":
             return
-        if autostart_check.get_active():
+        if autostart_check is not None and autostart_check.get_active():
             from castword.autostart import set_autostart_enabled
             set_autostart_enabled(True)
         if shortcut_check is not None and shortcut_check.get_active():

--- a/data/xyz.shapemachine.castword-gnome.gschema.xml
+++ b/data/xyz.shapemachine.castword-gnome.gschema.xml
@@ -75,6 +75,12 @@
       <description>Set to true after the first-run shortcut prompt is shown, so it is never repeated.</description>
     </key>
 
+    <key name="autostart-prompted" type="b">
+      <default>false</default>
+      <summary>Whether the launch-at-login prompt has been shown</summary>
+      <description>Set to true after the autostart prompt is shown, so it is never repeated. Existing users who upgrade see the prompt once even if shortcut-prompted is already true.</description>
+    </key>
+
     <!-- STT (Phase 2) — API keys stored in libsecret, not here -->
     <key name="stt-enabled" type="b">
       <default>false</default>


### PR DESCRIPTION
## Summary
- Add `castword/autostart.py` to manage an XDG autostart desktop file at
  `~/.config/autostart/` — file existence is the canonical state, keeping
  the toggle in sync with GNOME Tweaks automatically
- Add `--background` flag so the process starts silently at login (resident,
  holding D-Bus) without showing the window; keyboard shortcut presents it
  on first press
- Context-aware first-run dialog: new users see both checkboxes (shortcut +
  login launch), existing users upgrading see only "Launch at login"; a new
  `autostart-prompted` GSettings key gates the upgrade prompt

## Issues
Closes #97

## Test plan
- [ ] Fresh install: first launch shows "Set up castword" with both checkboxes pre-checked
- [ ] "Set Up": shortcut registered and autostart file written with resolved binary path
- [ ] "Not Now": neither configured; dialog doesn't re-appear on next launch
- [ ] Uncheck one item before "Set Up": only the checked item is acted on
- [ ] Existing user upgrading (shortcut set, no autostart): dialog shows only "Launch at login"
- [ ] Both already configured: no dialog shown at all
- [ ] Preferences → Behaviour → Startup: toggle creates/removes the autostart file
- [ ] Toggle reverts and shows toast if file write fails (e.g. permissions error)
- [ ] `castword --background`: process stays resident, no window; shortcut then presents normally
- [ ] Login with autostart enabled: castword starts silently, shortcut works immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)